### PR TITLE
Freiheit: RoHOW sponsor 2017

### DIFF
--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -42,7 +42,7 @@ title: Sponsoren
             <p>freiheit.com technologies gmbh baut Software für die digitale Zukunft und hilft seinen internationalen Kunden ihre Geschäftsmodelle in die digitale Welt zu transformieren. </p>
             <p>Gegründet 1999 in Hamburg, zählt <a href="http://freiheit.com/">freiheit.com</a> zu den Internet-Pionieren in Deutschland und entwickelt seitdem individuelle Software auf Basis von Internet-Technologien für das Who-is-Who der europäischen Industrie und Wirtschaft. Rund 80 Full-Stack-Engineers erarbeiten maßgeschneiderte Lösungen entlang der Strategien ihrer Kunden.</p>
             <p><a href="http://freiheit.com/">freiheit.com</a> steht sowohl für technologische Kompetenz & Zuverlässigkeit wie Agilität & Schnelligkeit; “Silicon Valley Culture meets German Engineering”.</p>
-            <p>Seit 2016 ist freiheit.com Sponsor der HULKs und Sponsor des RoHOW 2016. Wir freuen uns sehr über die Unterstützung dieser Software-Experten.</p>
+            <p>Seit 2016 ist freiheit.com Sponsor der HULKs sowie des RoHOWs. Wir freuen uns sehr über die Unterstützung dieser Software-Experten.</p>
         </div><figure class="col-4-10 photo">
           <img src="{{site.path}}/_photos/freiheit.png" />
         </figure>


### PR DESCRIPTION
Man könnte wohl auch `Seit 2016 ist freiheit.com Sponsor der HULKs und Sponsor des RoHOW 2016 und 2017` schreiben.